### PR TITLE
44 - Improving the usability of the generators and fixing tests

### DIFF
--- a/libs/ddd-angular/src/generators/feature/generator.spec.ts
+++ b/libs/ddd-angular/src/generators/feature/generator.spec.ts
@@ -93,38 +93,20 @@ describe('feature generator', () => {
   });
 
   it('should generate a default facade, model, data-service, and component in the domain', async () => {
+    const expectedChanges = [
+      {
+        path: `libs/${defaultOptions.domain}/domain/src/lib/application/${defaultOptions.name}.facade.ts`,
+        type: 'CREATE',
+      }
+    ];
     await setup(appTree);
 
     const changes = appTree.listChanges().map((change) => ({
       type: change.type,
       path: change.path,
     }));
-    const expectedChanges = [
-      {
-        path: `libs/${defaultOptions.domain}/domain/src/lib/application/feature-${defaultOptions.name}.facade.ts`,
-        type: 'CREATE',
-      },
-      {
-        path: `libs/${defaultOptions.domain}/domain/src/lib/entities/${defaultOptions.name}.ts`,
-        type: 'CREATE',
-      },
-      {
-        path: `libs/${defaultOptions.domain}/domain/src/lib/infrastructure/${defaultOptions.name}.data.service.ts`,
-        type: 'CREATE',
-      },
-      {
-        path: `libs/${defaultOptions.domain}/feature-${defaultOptions.name}/src/lib/feature-${defaultOptions.name}.component.html`,
-        type: 'CREATE',
-      },
-      {
-        path: `libs/${defaultOptions.domain}/feature-${defaultOptions.name}/src/lib/feature-${defaultOptions.name}.component.scss`,
-        type: 'CREATE',
-      },
-      {
-        path: `libs/${defaultOptions.domain}/feature-${defaultOptions.name}/src/lib/feature-${defaultOptions.name}.component.ts`,
-        type: 'CREATE',
-      },
-    ];
+
+    console.log(changes);
 
     expectedChanges.forEach((expectedChange) => {
       expect(changes).toContainEqual(expectedChange);

--- a/libs/ddd-angular/src/generators/feature/generator.spec.ts
+++ b/libs/ddd-angular/src/generators/feature/generator.spec.ts
@@ -106,8 +106,6 @@ describe('feature generator', () => {
       path: change.path,
     }));
 
-    console.log(changes);
-
     expectedChanges.forEach((expectedChange) => {
       expect(changes).toContainEqual(expectedChange);
     });

--- a/libs/ddd-angular/src/generators/feature/generator.spec.ts
+++ b/libs/ddd-angular/src/generators/feature/generator.spec.ts
@@ -97,7 +97,7 @@ describe('feature generator', () => {
       {
         path: `libs/${defaultOptions.domain}/domain/src/lib/application/${defaultOptions.name}.facade.ts`,
         type: 'CREATE',
-      }
+      },
     ];
     await setup(appTree);
 

--- a/libs/ddd-angular/src/generators/feature/generator.ts
+++ b/libs/ddd-angular/src/generators/feature/generator.ts
@@ -12,11 +12,11 @@ export default async function (tree: Tree, options: DddFeatureGeneratorSchema) {
   const domainName = domainNameFromProject(tree, options.domain);
 
   await dddFeatureGenerator(tree, {
-    name: `feature-${options.name}`,
+    name: options.name,
+    prefix: true,
     domain: domainName,
     noApp: true,
     standalone: false,
-    entity: options.name,
     type: 'buildable',
   });
   removeFiles(tree, `${domainName}-feature-${options.name}`);


### PR DESCRIPTION
# Description

Improving the feature generator to not create boiler plate as it would lead to more confusion than anything else.
Now when creating a feature, it will not setup a component with an ugly table. 
It will not add entities or data-service for you when it should be the decision of the dev.

Also using a prefix instead of adding the prefix on the name of the generator. 
Previously it would add feature as a facade, when in fact it should be handled by the generator.

Fixes #44 

Thank you for contributing to our NX-Generatorz repo!
:rocket:(づ｡◕‿‿◕｡)づ:rocket:
